### PR TITLE
Improve design creator with patterns and cart feature

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -777,7 +777,7 @@
 
           <!-- Creator Page -->
           <div v-if="currentPage === 'Creator'" class="container mx-auto px-4 py-8">
-            <DesignCreator />
+            <DesignCreator @add-to-cart="addCustomDesignToCart" />
           </div>
 
           <!-- Enhanced Cart Sidebar -->
@@ -1237,6 +1237,18 @@ const addToCart = (product, quantity = 1) => {
   selectedSize.value = null;
   selectedColor.value = null;
   quantity.value = 1;
+};
+
+const addCustomDesignToCart = ({ image, price }) => {
+  cart.value.push({
+    id: Date.now(),
+    name: 'Eigenes Design',
+    image,
+    price,
+    quantity: 1
+  });
+  localStorage.setItem('cart', JSON.stringify(cart.value));
+  alert('Design wurde zum Warenkorb hinzugefügt');
 };
 
 const removeFromCart = (index) => {


### PR DESCRIPTION
## Summary
- enhance DesignCreator with selectable patterns and Fabric.js patterns
- allow saving custom design to cart
- emit `add-to-cart` event from creator component
- handle `add-to-cart` event in app.vue to store custom item in cart

## Testing
- `npm run build` *(fails: `nuxt` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c625bbf90832f9041988383dba18a